### PR TITLE
fix packbits extension bug of pytoshop

### DIFF
--- a/scripts/layer_divider_modules/installation.py
+++ b/scripts/layer_divider_modules/installation.py
@@ -1,4 +1,3 @@
-import sys
 import os
 
 base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
@@ -12,3 +11,32 @@ def install_sam():
             if not is_installed(package):
                 run_pip(
                     f"install {package}", f"Layer Divider Extension: Installing  {package}")
+    install_packbits_so_file()
+
+def install_packbits_so_file():
+    SO_FILES = {
+        "packbits.cpython-36m-darwin.so": "https://github.com/jhj0517/pytoshop_packbits_extension/blob/master/packbits_so/packbits.cpython-36m-darwin.so?raw=true",
+        "packbits.cpython-37m-darwin.so": "https://github.com/jhj0517/pytoshop_packbits_extension/blob/master/packbits_so/packbits.cpython-37m-darwin.so?raw=true",
+        "packbits.cpython-38-darwin.so": "https://github.com/jhj0517/pytoshop_packbits_extension/blob/master/packbits_so/packbits.cpython-38-darwin.so?raw=true",
+        "packbits.cpython-39-darwin.so": "https://github.com/jhj0517/pytoshop_packbits_extension/blob/master/packbits_so/packbits.cpython-39-darwin.so?raw=true",
+        "packbits.cpython-310-darwin.so": "https://github.com/jhj0517/pytoshop_packbits_extension/blob/master/packbits_so/packbits.cpython-310-darwin.so?raw=true",
+        "packbits.cpython-311-darwin.so": "https://github.com/jhj0517/pytoshop_packbits_extension/blob/master/packbits_so/packbits.cpython-311-darwin.so?raw=true",
+    }
+
+    import sys
+    import platform
+    import urllib.request
+
+    if platform.system() == "Darwin":
+        sd_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
+        pytoshop_path = os.path.join(sd_path, 'venv', 'Lib', 'site-packages', 'pytoshop')
+        if not os.path.exists(pytoshop_path):
+            print("pytoshop is not installed:", pytoshop_path)
+            return
+
+        so_file_name = f"packbits.cpython-{sys.version_info.major}{sys.version_info.minor}-darwin.so"
+        so_file_path = os.path.join(pytoshop_path, so_file_name)
+
+        if not os.path.exists(so_file_path):
+            print(f"packbits so file is not detected. downloading {so_file_name}")
+            urllib.request.urlretrieve(SO_FILES[so_file_name], so_file_path)


### PR DESCRIPTION
This PR is meant to resolve the #5 

When pytoshop is installed with cython, the `.so` and `.pyd` files are not properly generated, causing issues.

This is focused on macOS, as it appears that the issue in Windows has been resolved in #2 
- related issue
  - [pytoshop #9](https://github.com/mdboom/pytoshop/issues/9)

After investigating the issue, it appears that there are some bugs with installing extensions with `cython` using `setuptools`.
- related issue
  - [setuptools #3891](https://github.com/pypa/setuptools/issues/3891)
  - [setuptools #3786](https://github.com/pypa/setuptools/issues/3786)

To solve this issue, I decided to directly download the `so` file.