### PR TITLE
fix packbits extension bug

### DIFF
--- a/layer_divider_requirements.txt
+++ b/layer_divider_requirements.txt
@@ -1,4 +1,4 @@
 segment-anything
 opencv-python
 pycocotools
-pytoshop==1.1.0 --no-cache-dir
+pytoshop==1.1.0

--- a/scripts/layer_divider_modules/installation.py
+++ b/scripts/layer_divider_modules/installation.py
@@ -1,6 +1,10 @@
 import os
+from setuptools.command.build_ext import build_ext
 
 base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sd_path = os.path.abspath(os.path.join(base_dir, '..', '..'))
+pytoshop_path = os.path.join(sd_path, 'venv', 'Lib', 'site-packages', 'pytoshop')
+
 
 def install_sam():
     req_file_path = os.path.join(base_dir, 'layer_divider_requirements.txt')
@@ -11,3 +15,51 @@ def install_sam():
             if not is_installed(package):
                 run_pip(
                     f"install {package}", f"Layer Divider Extension: Installing  {package}")
+
+    is_extension_there = any(filename.endswith(('.so', '.pyd')) for filename in os.listdir(pytoshop_path))
+    if not is_extension_there:
+        build_packbits()
+
+
+def build_packbits():
+    from setuptools import setup
+    from setuptools.extension import Extension
+
+    try:
+        from Cython.Build import cythonize
+    except ImportError:
+        extensions = []
+    else:
+        extensions = cythonize([
+            Extension(
+                f"pytoshop.packbits",
+                [os.path.join(pytoshop_path, "packbits.pyx")],
+            )
+        ])
+
+    setup(
+        name="pytoshop-packbits",
+        ext_modules=extensions,
+        cmdclass={'build_ext': CustomBuildExtCommand},
+        script_args=['build_ext'],
+    )
+
+
+class CustomBuildExtCommand(build_ext):
+    def get_ext_fullpath(self, ext_name):
+        ext_path = ext_name.split('.')
+        ext_suffix = self.get_ext_filename(ext_path[-1])
+        filepath = os.path.join(pytoshop_path, 'packbits_temp' + ext_suffix)
+        return filepath
+
+    def run(self):
+        # I don't know why, but the extension file is not being generated with the normal file name, so this needs to be done
+        build_ext.run(self)
+
+        for filename in os.listdir(pytoshop_path):
+            if filename.startswith('packbits_temp'):
+                new_filename = filename.replace('packbits_temp', '', 1)
+                src = os.path.join(pytoshop_path, filename)
+                dst = os.path.join(pytoshop_path, new_filename)
+
+                os.rename(src, dst)


### PR DESCRIPTION
This PR is meant to resolve the #5 , again.
It appears to be related to a version conflict between `Cython` and `Python` versions.

- **related issue**
    - [#setuptools #3891](https://github.com/pypa/setuptools/issues/3891)
    
This error seems to be occurring in several OS.
-  **related issue**
   - [macOS](https://github.com/jhj0517/stable-diffusion-webui-Layer-Divider/issues/5#issuecomment-1505081569)
   - [Windows](https://github.com/jhj0517/stable-diffusion-webui-Layer-Divider/issues/5#issuecomment-1514388605)
  
When running `pip install pytoshop` in Python 3.6, the packbits extension file (`.so` or `.pyd`) is generated
However for Python versions 3.7 ~ 3.11, it is not generated

The action of `pip` should not differ from that of `setup.py`. However, when using `setup.py`, the so and pyd files are generated normally.

- **related issue**
     - [#pytoshop 9](https://github.com/mdboom/pytoshop/issues/9#issuecomment-425882128)
     
So I assume this error is related to a version conflict between `Cython` and `Python` versions.

In this PR, I've directly built the extension.

     